### PR TITLE
Fix bug with industries and services tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Update Spanish translation [macagua]
 
+- Fix bug with industries and services tags [instification]
+
 
 ## 1.0.0a3 (2023-06-01)
 

--- a/src/collective/casestudy/vocabularies/industries.py
+++ b/src/collective/casestudy/vocabularies/industries.py
@@ -11,6 +11,7 @@ def industries_vocabulary(context):
     terms = []
     industries = api.portal.get_registry_record("casestudy.industries")
     for title in industries:
+        token = title
         if "|" in title:
             token, title = title.split("|")
         terms.append(SimpleTerm(token, token, title))

--- a/src/collective/casestudy/vocabularies/services.py
+++ b/src/collective/casestudy/vocabularies/services.py
@@ -11,6 +11,7 @@ def services_vocabulary(context):
     terms = []
     services = api.portal.get_registry_record("casestudy.services")
     for title in services:
+        token = title
         if "|" in title:
             token, title = title.split("|")
         terms.append(SimpleTerm(token, token, title))


### PR DESCRIPTION
In both these cases if the title isn't containing a "|" character an exception is raised as the `token` var is not set.

Simple bugfix for this case. We can see it has been coded correctly in usages.py: https://github.com/collective/collective.casestudy/blob/122d6a98ab96251332c075c6c4180536c807641e/src/collective/casestudy/vocabularies/usages.py#L9-L18